### PR TITLE
Removing unnecessary use of sudo in zone reload

### DIFF
--- a/deployzones.sh
+++ b/deployzones.sh
@@ -47,8 +47,8 @@ else
   for file in $CHANGEDFILES; do
     zone=$(echo "$file" | cut -d"/" -f2 | sed "s/zone//")
     log_info2 "Reloading zone ${zone} with knotc"
-    ssh "$SSH_USER"@"$NS_HIDDENMASTER" sudo knotc zone-reload "$zone"
-    ssh "$SSH_USER"@"$NS_HIDDENMASTER" sudo knotc zone-status "$zone"
+    ssh "$SSH_USER"@"$NS_HIDDENMASTER" knotc zone-reload "$zone"
+    ssh "$SSH_USER"@"$NS_HIDDENMASTER" knotc zone-status "$zone"
   done
 fi
 


### PR DESCRIPTION
This change is removing the use of root privileges in zone reload if single zones are changed.
In most setups, it is totally sufficient to supply a user authorized to use knotc, i.e. a user in the knot group.

This change aims to increase security and reduce privileges hold and used by an automated (possibly remote) user.

fixes #1 